### PR TITLE
Upgrade to 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,8 +11,8 @@
         "DOM"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/childNodes.elm
+++ b/examples/childNodes.elm
@@ -1,3 +1,5 @@
+module Main exposing (..)
+
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
@@ -6,12 +8,11 @@ import Platform.Cmd exposing (none)
 import Platform.Sub
 import Json.Decode as Decode exposing (Decoder)
 import String
-
 import DOM exposing (..)
 
 
-type alias Model
-  = String
+type alias Model =
+  String
 
 
 model0 : Model
@@ -19,28 +20,35 @@ model0 =
   "(Nothing)"
 
 
-type Msg = 
-  Measure String
+type Msg
+  = Measure String
 
 
-update : Msg -> Model -> (Model, Cmd Msg)
-update msg model = 
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
   case msg of
-    Measure str -> 
-      (str, none)
+    Measure str ->
+      ( str, none )
 
 
 items : Html a
 items =
-  [0..5]
-  |> List.map (\idx ->
-    li
-      -- elm-dom will later extract the class names directly from the DOM out of
-      -- the elements.
-      [ class <| "class-" ++ (toString idx) ]
-      [ text <| "Item " ++ toString idx ]
-  ) -- childNodes
-  |> ul [] --childNode 0 (b)
+  List.range 0 5
+    |> List.map
+      (\idx ->
+        li
+          -- elm-dom will later extract the class names directly from the DOM out of
+          -- the elements.
+          [ class <| "class-" ++ (toString idx) ]
+          [ text <| "Item " ++ toString idx ]
+      )
+    -- childNodes
+    |>
+      ul []
+
+
+
+--childNode 0 (b)
 
 
 infixr 5 :>
@@ -52,34 +60,45 @@ infixr 5 :>
 decode : Decoder String
 decode =
   DOM.target
-  :> parentElement
-  :> childNode 0 -- (a)
-  :> childNode 0 -- (b)
-  :> childNodes className -- Extract the class name from the elements
-  |> Decode.map (String.join ", ")
+    :> parentElement
+    :> childNode 0
+    -- (a)
+    :>
+      childNode 0
+    -- (b)
+    :>
+      childNodes className
+    -- Extract the class name from the elements
+    |>
+      Decode.map (String.join ", ")
 
 
 view : Model -> Html Msg
 view model =
-  div -- parentElement
+  div
+    -- parentElement
     [ class "root" ]
-    [ div -- childNode 0 (a)
-        [ class "container"]
-        [ items ] -- See childNode 0 (b) in the above "items" function
+    [ div
+      -- childNode 0 (a)
+      [ class "container" ]
+      [ items ]
+      -- See childNode 0 (b) in the above "items" function
     , div
-        [ class "value" ]
-        [ text <| "Model value: " ++ toString model ]
-    , map Measure <| button -- target
+      [ class "value" ]
+      [ text <| "Model value: " ++ toString model ]
+    , map Measure <|
+      button
+        -- target
         [ class "button"
-        , on "click" decode  
+        , on "click" decode
         ]
         [ text "Click" ]
     ]
 
 
 main : Program Never
-main = 
-  Html.App.program 
+main =
+  Html.App.program
     { init = ( model0, none )
     , update = update
     , subscriptions = always Sub.none

--- a/examples/post.elm
+++ b/examples/post.elm
@@ -1,3 +1,5 @@
+module Main exposing (..)
+
 import Html.App exposing (map)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -6,31 +8,33 @@ import Platform.Cmd exposing (none)
 import Platform.Sub
 import String
 import Json.Decode exposing (Decoder)
-
 import DOM exposing (..)
 
 
-type alias Model = 
+type alias Model =
   List Float
 
 
-model : Model 
-model = 
+model : Model
+model =
   []
 
 
-type Msg 
+type Msg
   = Measure (List Float)
 
 
-init : (Model, Cmd Msg)
-init = ([], none)
+init : ( Model, Cmd Msg )
+init =
+  ( [], none )
 
 
-update : Msg -> Model -> (Model, Cmd Msg)
-update action model = 
+update : Msg -> Model -> ( Model, Cmd Msg )
+update action model =
   case action of
-    Measure measures -> (measures, none)
+    Measure measures ->
+      ( measures, none )
+
 
 
 -- VIEW
@@ -38,52 +42,72 @@ update action model =
 
 infixr 5 :>
 (:>) : (a -> b) -> a -> b
-(:>) f x = 
+(:>) f x =
   f x
 
 
 decode : Decoder (List Float)
-decode = 
-  DOM.target                    -- (a)
-  :> parentElement              -- (b)
-  :> childNode 0                -- (c)
-  :> childNode 0                -- (d)
-  :> childNodes                 -- (e)
-       DOM.offsetWidth          -- read the width of each element
+decode =
+  DOM.target
+    -- (a)
+    :>
+      parentElement
+    -- (b)
+    :>
+      childNode 0
+    -- (c)
+    :>
+      childNode 0
+    -- (d)
+    :>
+      childNodes
+        -- (e)
+        DOM.offsetWidth
+
+
+
+-- read the width of each element
 
 
 css : Attribute a
-css = 
-  style [ ("padding", "1em") ]
+css =
+  style [ ( "padding", "1em" ) ]
 
 
 view : Model -> Html Msg
-view model = 
-  div -- parentElement (b)
+view model =
+  div
+    -- parentElement (b)
     []
-    [ div -- childNode 0 (c)
-        [ css ]
-        [ div -- childNode 0 (d)
-            []
-            [ span [ css ] [ text "short" ] 
-            , span [ css ] [ text "somewhat long" ] 
-            , span [ css ] [ text "longer than the others" ]
-            ] -- childNodes (e)
+    [ div
+      -- childNode 0 (c)
+      [ css ]
+      [ div
+        -- childNode 0 (d)
+        []
+        [ span [ css ] [ text "short" ]
+        , span [ css ] [ text "somewhat long" ]
+        , span [ css ] [ text "longer than the others" ]
         ]
-    , map Measure <| button -- target (a)
+        -- childNodes (e)
+      ]
+    , map Measure <|
+      button
+        -- target (a)
         [ css
-        , on "click" decode 
+        , on "click" decode
         ]
         [ text "Measure!" ]
-    , div 
-        [ css ]
-        [ model 
-          |> List.map toString
-          |> String.join ", "
-          |> text 
-        , text "!"
-        ]
+    , div
+      [ css ]
+      [ model
+        |> List.map toString
+        |> String.join ", "
+        |> text
+      , text "!"
+      ]
     ]
+
 
 
 -- STARTAPP
@@ -91,11 +115,9 @@ view model =
 
 main : Program Never
 main =
-  Html.App.program 
-    { init = ( model, none ) 
+  Html.App.program
+    { init = ( model, none )
     , view = view
     , subscriptions = always Sub.none
     , update = update
     }
-
-

--- a/examples/post2.elm
+++ b/examples/post2.elm
@@ -1,3 +1,5 @@
+module Main exposing (..)
+
 import Html.App exposing (map)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -6,41 +8,43 @@ import Platform.Cmd exposing (none)
 import Platform.Sub
 import String
 import Json.Decode as Json exposing (Decoder)
-
 import DOM exposing (..)
 
 
-type alias Model = 
+type alias Model =
   () -> List Float
 
 
-model : Model 
-model = 
+model : Model
+model =
   always []
 
 
-type Msg 
+type Msg
   = Measure Json.Value
   | NoOp
 
 
-init : (Model, Cmd Msg)
-init = (always [], none)
+init : ( Model, Cmd Msg )
+init =
+  ( always [], none )
 
 
-update : Msg -> Model -> (Model, Cmd Msg)
-update action model = 
+update : Msg -> Model -> ( Model, Cmd Msg )
+update action model =
   case action of
-    Measure val -> 
-      ((\_ -> 
+    Measure val ->
+      ( (\_ ->
         Json.decodeValue decode val
           |> Result.toMaybe
-          |> Maybe.withDefault [] 
-       )
-      , none)
+          |> Maybe.withDefault []
+        )
+      , none
+      )
 
-    NoOp -> 
-      (model, none)
+    NoOp ->
+      ( model, none )
+
 
 
 -- VIEW
@@ -48,59 +52,79 @@ update action model =
 
 infixr 5 :>
 (:>) : (a -> b) -> a -> b
-(:>) f x = 
+(:>) f x =
   f x
 
 
 decode : Decoder (List Float)
-decode = 
-  DOM.target                    -- (a)
-  :> parentElement              -- (b)
-  :> childNode 0                -- (c)
-  :> childNode 0                -- (d)
-  :> childNodes                 -- (e)
-       DOM.offsetHeight          -- read the width of each element
+decode =
+  DOM.target
+    -- (a)
+    :>
+      parentElement
+    -- (b)
+    :>
+      childNode 0
+    -- (c)
+    :>
+      childNode 0
+    -- (d)
+    :>
+      childNodes
+        -- (e)
+        DOM.offsetHeight
+
+
+
+-- read the width of each element
 
 
 css : Attribute a
-css = 
-  style [ ("padding", "1em") ]
+css =
+  style [ ( "padding", "1em" ) ]
 
 
 view : Model -> Html Msg
-view model = 
-  div -- parentElement (b)
+view model =
+  div
+    -- parentElement (b)
     []
-    [ div -- childNode 0 (c)
-        [ css ]
-        [ div -- childNode 0 (d)
-            []
-            [ span [ css ] [ text "short" ] 
-            , span [ css ] [ text "somewhat long" ] 
-            , span [ css ] [ text "longer than the others" ]
-            , span [ css ] [ text "much longer than the others" ]
-            ] -- childNodes (e)
+    [ div
+      -- childNode 0 (c)
+      [ css ]
+      [ div
+        -- childNode 0 (d)
+        []
+        [ span [ css ] [ text "short" ]
+        , span [ css ] [ text "somewhat long" ]
+        , span [ css ] [ text "longer than the others" ]
+        , span [ css ] [ text "much longer than the others" ]
         ]
-    , map Measure <| button -- target (a)
+        -- childNodes (e)
+      ]
+    , map Measure <|
+      button
+        -- target (a)
         [ css
-        , on "click" Json.value 
+        , on "click" Json.value
         ]
         [ text "Measure!" ]
-    , button 
-        [ css 
-        , onClick NoOp
-        ]
-        [ text "Call the function."
-        ]
-    , div 
-        [ css ]
-        [ model ()
-          |> List.map toString
-          |> String.join ", "
-          |> text 
-        , text "!"
-        ]
+    , button
+      [ css
+      , onClick NoOp
+      ]
+      [ text "Call the function."
+      ]
+    , div
+      [ css ]
+      [ model ()
+        |> List.map toString
+        |> String.join ", "
+        |> text
+      , text "!"
+      ]
     ]
+
 
 
 -- APP
@@ -114,4 +138,3 @@ main =
     , update = update
     , view = view
     }
-

--- a/src/DOM.elm
+++ b/src/DOM.elm
@@ -1,13 +1,22 @@
-module DOM exposing
-  ( target, offsetParent, parentElement
-  , nextSibling, previousSibling
-  , childNode, childNodes
-  , offsetWidth, offsetHeight
-  , offsetLeft, offsetTop
-  , scrollLeft, scrollTop
-  , Rectangle, boundingClientRect
-  , className
-  ) 
+module DOM
+  exposing
+    ( target
+    , offsetParent
+    , parentElement
+    , nextSibling
+    , previousSibling
+    , childNode
+    , childNodes
+    , offsetWidth
+    , offsetHeight
+    , offsetLeft
+    , offsetTop
+    , scrollLeft
+    , scrollTop
+    , Rectangle
+    , boundingClientRect
+    , className
+    )
 
 {-| You read values off the DOM by constructing a JSON decoder.
 See the `target` value for example use.
@@ -35,129 +44,134 @@ for the precise semantics of these measurements. See also
 @docs className
 -}
 
-import Json.Decode as Decode exposing ((:=), at, andThen, Decoder)
+import Json.Decode as Decode exposing (field, at, andThen, Decoder)
 
 
 {-| Get the target DOM element of an event. You will usually start with this
 decoder. E.g., to make a button which when clicked emit an Action that carries
 the width of the button:
 
-    import DOM exposing (target, offsetWidth)
+  import DOM exposing (target, offsetWidth)
 
-    myButton : Html Float
-    myButton =
-      button
-        [ on "click" (target offsetWidth) ]
-        [ text "Click me!" ]
+  myButton : Html Float
+  myButton =
+    button
+    [ on "click" (target offsetWidth) ]
+    [ text "Click me!" ]
 -}
 target : Decoder a -> Decoder a
 target decoder =
-  "target" := decoder
+  field "target" decoder
 
 
 {-| Get the offsetParent of the current element. Returns first argument if the current
 element is already the root; applies the second argument to the parent element
 if not.
 
-To do traversals of the DOM, exploit that Elm allows recursive values. 
+To do traversals of the DOM, exploit that Elm allows recursive values.
 -}
 offsetParent : a -> Decoder a -> Decoder a
 offsetParent x decoder =
   Decode.oneOf
-  [ "offsetParent" := Decode.null x
-  , "offsetParent" := decoder
-  ]
+    [ field "offsetParent" <| Decode.null x
+    , field "offsetParent" decoder
+    ]
 
 
 {-| Get the next sibling of an element.
 -}
 nextSibling : Decoder a -> Decoder a
 nextSibling decoder =
-  "nextSibling" := decoder
+  field "nextSibling" decoder
 
 
 {-| Get the previous sibling of an element.
 -}
 previousSibling : Decoder a -> Decoder a
 previousSibling decoder =
-  "previousSibling" := decoder
+  field "previousSibling" decoder
 
 
-{-| Get the parent of an element. 
+{-| Get the parent of an element.
 -}
 parentElement : Decoder a -> Decoder a
-parentElement decoder = 
-  "parentElement" := decoder
+parentElement decoder =
+  field "parentElement" decoder
 
 
-{-| Find the ith child of an element. 
+{-| Find the ith child of an element.
 -}
 childNode : Int -> Decoder a -> Decoder a
-childNode idx = 
+childNode idx =
   at [ "childNodes", toString idx ]
 
 
 {-| Get the children of an element.
 -}
 childNodes : Decoder a -> Decoder (List a)
-childNodes decoder = 
+childNodes decoder =
   let
-    loop idx xs = 
-      Decode.maybe (toString idx := decoder)
-        `andThen` (
-          Maybe.map (\x -> loop (idx+1) (x::xs))
+    loop idx xs =
+      Decode.maybe (field (toString idx) decoder)
+        |> andThen
+          (Maybe.map (\x -> loop (idx + 1) (x :: xs))
             >> Maybe.withDefault (Decode.succeed xs)
-        )
+          )
   in
-    ("childNodes" := loop 0 [])
+    (field "childNodes" <| loop 0 [])
       |> Decode.map List.reverse
 
 
 
-
--- GEOMETRY 
+-- GEOMETRY
 
 
 {-| Get the width of an element in pixels; underlying implementation
 reads `.offsetWidth`.
 -}
 offsetWidth : Decoder Float
-offsetWidth = "offsetWidth" := Decode.float
+offsetWidth =
+  field "offsetWidth" Decode.float
 
 
 {-| Get the heigh of an element in pixels. Underlying implementation
 reads `.offsetHeight`.
 -}
 offsetHeight : Decoder Float
-offsetHeight = "offsetHeight" := Decode.float
+offsetHeight =
+  field "offsetHeight" Decode.float
 
 
 {-| Get the left-offset of the element in the parent element in pixels.
 Underlying implementation reads `.offsetLeft`.
 -}
 offsetLeft : Decoder Float
-offsetLeft = "offsetLeft" := Decode.float
+offsetLeft =
+  field "offsetLeft" Decode.float
 
 
 {-| Get the top-offset of the element in the parent element in pixels.
 Underlying implementation reads `.offsetTop`.
 -}
 offsetTop : Decoder Float
-offsetTop = "offsetTop" := Decode.float
+offsetTop =
+  field "offsetTop" Decode.float
 
 
 {-| Get the amount of left scroll of the element in pixels.
 Underlying implementation reads `.scrollLeft`.
 -}
 scrollLeft : Decoder Float
-scrollLeft = "scrollLeft" := Decode.float
+scrollLeft =
+  field "scrollLeft" Decode.float
 
 
 {-| Get the amount of top scroll of the element in pixels.
 Underlying implementation reads `.scrollTop`.
 -}
 scrollTop : Decoder Float
-scrollTop = "scrollTop" := Decode.float
+scrollTop =
+  field "scrollTop" Decode.float
 
 
 {-| Types for rectangles.
@@ -177,7 +191,7 @@ based off
 
 NB! This decoder produces wrong results if a parent element is scrolled and
 does not have explicit positioning (e.g., `position: relative;`); see
-[this issue](https://github.com/debois/elm-dom/issues/4). 
+[this issue](https://github.com/debois/elm-dom/issues/4).
 
 Also note that this decoder is likely computationally expensive and may produce
 results that differ slightly from `getBoundingClientRect` in browser-dependent
@@ -191,44 +205,51 @@ presumably expensive JSON decoders.  It's 2007 forever, baby!)
 -}
 boundingClientRect : Decoder Rectangle
 boundingClientRect =
-  Decode.object3
-    (\(x, y) width height ->
+  Decode.map3
+    (\( x, y ) width height ->
       { top = y
       , left = x
       , width = width
       , height = height
-      })
+      }
+    )
     (position 0 0)
     offsetWidth
     offsetHeight
 
 
+
 {- This is what we're implementing (from the above link).
 
-    function getOffset( el ) {
-        var _x = 0;
-        var _y = 0;
-        while( el && !isNaN( el.offsetLeft ) && !isNaN( el.offsetTop ) ) {
-            _x += el.offsetLeft - el.scrollLeft;
-            _y += el.offsetTop - el.scrollTop;
-            el = el.offsetParent;
-        }
-        return { top: _y, left: _x };
-    }
-    var x = getOffset( document.getElementById('yourElId') ).left; )
+   function getOffset( el ) {
+     var _x = 0;
+     var _y = 0;
+     while( el && !isNaN( el.offsetLeft ) && !isNaN( el.offsetTop ) ) {
+       _x += el.offsetLeft - el.scrollLeft;
+       _y += el.offsetTop - el.scrollTop;
+       el = el.offsetParent;
+     }
+     return { top: _y, left: _x };
+   }
+   var x = getOffset( document.getElementById('yourElId') ).left; )
 -}
-position : Float -> Float -> Decoder (Float, Float)
+
+
+position : Float -> Float -> Decoder ( Float, Float )
 position x y =
-  Decode.object4
+  Decode.map4
     (\scrollLeft scrollTop offsetLeft offsetTop ->
-      (x + offsetLeft - scrollLeft, y + offsetTop - scrollTop))
+      ( x + offsetLeft - scrollLeft, y + offsetTop - scrollTop )
+    )
     scrollLeft
     scrollTop
     offsetLeft
     offsetTop
-  `andThen` (\(x',y') ->
-    offsetParent (x', y') (position x' y')
-  )
+    |> andThen
+      (\( x_, y_ ) ->
+        offsetParent ( x_, y_ ) (position x_ y_)
+      )
+
 
 
 -- MISC
@@ -237,7 +258,5 @@ position x y =
 {-| Get the class name(s) of an element.
 -}
 className : Decoder String
-className = 
+className =
   at [ "className" ] Decode.string
-
-


### PR DESCRIPTION
Addresses https://github.com/debois/elm-dom/issues/6

The migration is done using `elm-upgrade` and the latest version of `elm-format`.

Manually updated to use the new Json codecs (using `field` and `map`N).

`elm-format` is using 4 spaces by-default. I re-indented with 2 using `sed` . It has also re-formatted a whole bunch of things.
